### PR TITLE
Fixed MetaData() method in MbTiles.cs

### DIFF
--- a/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/MbTiles/MbTiles.cs
+++ b/sdkproject/Assets/Mapbox/Core/mapbox-sdk-cs/Platform/MbTiles/MbTiles.cs
@@ -140,7 +140,13 @@ timestamp   INTEGER NOT NULL,
 		{
 			TableQuery<metadata> tq = _sqlite.Table<metadata>();
 			if (null == tq) { return null; }
-			return tq.Select(r => new KeyValuePair<string, string>(r.name, r.value)).ToList().AsReadOnly();
+			
+			var collection = new List<KeyValuePair<String, String>>();
+			foreach (var row in tq.Select(r => r))
+			{
+				collection.Add(new KeyValuePair<string, string>(row.name, row.value));
+			}
+			return collection.AsReadOnly();
 		}
 
 


### PR DESCRIPTION
Fixed getting metadata from database

It used to return array of empty Strings. Not very useful :|

Now correctly returns metadata.









___
_As part of the process of submitting this PR, please:_
- [x] Document the PR changes
- [ ] Update the changelog
